### PR TITLE
feat: stream roast tokens with typewriter UX

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
   "manifest_version": 3,
   "host_permissions": [
     "https://ddzqz505u9.execute-api.eu-west-2.amazonaws.com/prod/burn",
-    "https://nam5v7o2loht7eea6spgacrs640yhmaf.lambda-url.eu-west-2.on.aws/*"
+    "https://nam5v7o2loht7eea6spgacrs640yhmaf.lambda-url.eu-west-2.on.aws/"
   ],
   "permissions": ["history", "storage"],
   "chrome_url_overrides": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "BrowserBurn",
   "short_name": "BB🌐🔥",
   "description": "Replaces your new tab page with spicy roasts based on your recent browsing history - a unique and fun way to browse every day!",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": "BasiliskAI",
   "minimum_chrome_version": "104",
   "icons": {
@@ -13,7 +13,8 @@
   },
   "manifest_version": 3,
   "host_permissions": [
-    "https://ddzqz505u9.execute-api.eu-west-2.amazonaws.com/prod/burn"
+    "https://ddzqz505u9.execute-api.eu-west-2.amazonaws.com/prod/burn",
+    "https://nam5v7o2loht7eea6spgacrs640yhmaf.lambda-url.eu-west-2.on.aws/*"
   ],
   "permissions": ["history", "storage"],
   "chrome_url_overrides": {

--- a/src/api/roast.ts
+++ b/src/api/roast.ts
@@ -1,5 +1,5 @@
-import { API_URL, HISTORY_HOURS } from "../constants/api";
-import { error, isLoading, roast } from "../stores/api";
+import { API_URL, STREAM_API_URL, HISTORY_HOURS } from "../constants/api";
+import { error, isLoading, isStreaming, roast } from "../stores/api";
 
 export const getRoast = async () => {
   console.debug("Fetching history...");
@@ -27,6 +27,7 @@ const onHistoryResults = async (history: chrome.history.HistoryItem[]) => {
     error.set("Oops, something went wrong. Please try again later.");
   } finally {
     isLoading.set(false);
+    isStreaming.set(false);
   }
 };
 
@@ -38,6 +39,56 @@ const roastHistory = async (
     .join("\n");
   console.debug(historyLines);
 
+  try {
+    return await streamRoast(historyLines);
+  } catch (e) {
+    console.warn("Stream failed, falling back to buffered endpoint", e);
+    isStreaming.set(false);
+    return await bufferedRoast(historyLines);
+  }
+};
+
+const streamRoast = async (historyLines: string): Promise<string> => {
+  const response = await fetch(STREAM_API_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      historyLines,
+    }),
+  });
+
+  if (!response.ok || !response.body) {
+    console.error(await response.text());
+    throw new Error(`Stream API error: ${response.status}`);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+    if (text.length > 0) {
+      isLoading.set(false);
+      isStreaming.set(true);
+      roast.set(text);
+    }
+  }
+  text += decoder.decode();
+
+  if (!text) {
+    throw new Error("Stream returned no content");
+  }
+  console.debug(text);
+
+  return text;
+};
+
+const bufferedRoast = async (historyLines: string): Promise<string> => {
   const response = await fetch(API_URL, {
     method: "POST",
     headers: {

--- a/src/components/Message.svelte
+++ b/src/components/Message.svelte
@@ -1,13 +1,36 @@
 <script lang="ts">
   export let text: string;
+  export let streaming = false;
 </script>
 
 <h2 class="font-serif font-medium text-2xl">
-  {text}
+  {text}{#if streaming}<span class="cursor" aria-hidden="true" />{/if}
 </h2>
 
 <style>
   .font-serif {
     font-family: "Cormorant Garamond", serif;
+  }
+
+  .cursor {
+    display: inline-block;
+    width: 0.45em;
+    height: 1em;
+    margin-left: 0.1em;
+    vertical-align: text-bottom;
+    background-color: currentColor;
+    animation: blink 1s steps(2, start) infinite;
+  }
+
+  @keyframes blink {
+    50% {
+      opacity: 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cursor {
+      animation: none;
+    }
   }
 </style>

--- a/src/components/Roast.svelte
+++ b/src/components/Roast.svelte
@@ -2,7 +2,7 @@
   import { onMount } from "svelte";
   import loadingMessages from "../constants/loadingMessages";
   import { theme } from "../stores/theme";
-  import { isLoading, roast, error } from "../stores/api";
+  import { isLoading, isStreaming, roast, error } from "../stores/api";
   import { getRoast } from "../api/roast";
   import Loading from "./Loading.svelte";
   import Message from "./Message.svelte";
@@ -33,6 +33,8 @@
     <Message text={$error} />
   {:else}
     <Message text={$roast} />
-    <p class="font-bold mt-5">Sincerely, your browsing history</p>
+    {#if !$isStreaming}
+      <p class="font-bold mt-5">Sincerely, your browsing history</p>
+    {/if}
   {/if}
 </div>

--- a/src/components/Roast.svelte
+++ b/src/components/Roast.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { fade } from "svelte/transition";
   import loadingMessages from "../constants/loadingMessages";
   import { theme } from "../stores/theme";
-  import { isLoading, isStreaming, roast, error } from "../stores/api";
+  import { isLoading, isStreaming, error } from "../stores/api";
+  import { displayedRoast, isTyping } from "../stores/typewriter";
   import { getRoast } from "../api/roast";
   import Loading from "./Loading.svelte";
   import Message from "./Message.svelte";
 
   const loadingMessage =
     loadingMessages[Math.floor(Math.random() * loadingMessages.length)];
+
+  let contentHeight: number;
 
   // For testing purposes
   // isLoading.set(true);
@@ -23,18 +27,38 @@
 </script>
 
 <div
-  class="w-7/12 max-w-7xl p-5 rounded-[10px]"
+  class="w-7/12 max-w-7xl rounded-[10px] overflow-hidden roast-container"
   style:background-color={$theme.bgRoast}
   style:color={$theme.textRoast}
+  style:height={contentHeight ? `${contentHeight}px` : "auto"}
 >
-  {#if $isLoading}
-    <Loading message={loadingMessage} />
-  {:else if $error}
-    <Message text={$error} />
-  {:else}
-    <Message text={$roast} />
-    {#if !$isStreaming}
-      <p class="font-bold mt-5">Sincerely, your browsing history</p>
+  <div class="p-5" bind:clientHeight={contentHeight}>
+    {#if $isLoading}
+      <Loading message={loadingMessage} />
+    {:else if $error}
+      <Message text={$error} />
+    {:else}
+      <Message
+        text={$displayedRoast ?? ""}
+        streaming={$isStreaming || $isTyping}
+      />
+      {#if !$isStreaming && !$isTyping}
+        <p in:fade={{ duration: 400 }} class="font-bold mt-5">
+          Sincerely, your browsing history
+        </p>
+      {/if}
     {/if}
-  {/if}
+  </div>
 </div>
+
+<style>
+  .roast-container {
+    transition: height 250ms ease-out;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .roast-container {
+      transition: none;
+    }
+  }
+</style>

--- a/src/components/Share/ShareCard.svelte
+++ b/src/components/Share/ShareCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {afterUpdate} from "svelte";
   import {isLoading, isStreaming, roast, error} from "../../stores/api";
+  import {isTyping} from "../../stores/typewriter";
   import {theme} from "../../stores/theme";
   import ShareButton from "./ShareButton.svelte";
   import ShareTargets from "./ShareTargets.svelte";
@@ -61,7 +62,7 @@
 
 <!-- Modal toggle -->
 {#if !$error}
-  <ShareButton disabled={$isLoading || $isStreaming} onClick={openShareCard}/>
+  <ShareButton disabled={$isLoading || $isStreaming || $isTyping} onClick={openShareCard}/>
 {/if}
 
 {#if shareCardIsOpen}

--- a/src/components/Share/ShareCard.svelte
+++ b/src/components/Share/ShareCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import {afterUpdate} from "svelte";
-  import {isLoading, roast, error} from "../../stores/api";
+  import {isLoading, isStreaming, roast, error} from "../../stores/api";
   import {theme} from "../../stores/theme";
   import ShareButton from "./ShareButton.svelte";
   import ShareTargets from "./ShareTargets.svelte";
@@ -61,7 +61,7 @@
 
 <!-- Modal toggle -->
 {#if !$error}
-  <ShareButton disabled={$isLoading} onClick={openShareCard}/>
+  <ShareButton disabled={$isLoading || $isStreaming} onClick={openShareCard}/>
 {/if}
 
 {#if shareCardIsOpen}

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,3 +1,5 @@
 export const API_URL =
   "https://ddzqz505u9.execute-api.eu-west-2.amazonaws.com/prod/burn";
+export const STREAM_API_URL =
+  "https://nam5v7o2loht7eea6spgacrs640yhmaf.lambda-url.eu-west-2.on.aws/";
 export const HISTORY_HOURS = 2;

--- a/src/stores/api.ts
+++ b/src/stores/api.ts
@@ -1,5 +1,6 @@
 import { writable } from "svelte/store";
 
 export const isLoading = writable(true);
+export const isStreaming = writable(false);
 export const roast = writable<string | null>(null);
 export const error = writable<string | null>(null);

--- a/src/stores/typewriter.ts
+++ b/src/stores/typewriter.ts
@@ -1,0 +1,75 @@
+import { derived, readable } from "svelte/store";
+import { roast } from "./api";
+
+// Reveal speed while keeping pace with the stream; extra speed per character
+// of backlog so bursts and buffered fallbacks catch up within ~half a second.
+const BASE_CHARS_PER_SECOND = 40;
+const CATCH_UP_PER_BACKLOG_CHAR = 3;
+
+const prefersReducedMotion = window.matchMedia(
+  "(prefers-reduced-motion: reduce)"
+).matches;
+
+export const displayedRoast = readable<string | null>(null, (set) => {
+  let target: string | null = null;
+  let shown = 0;
+  let carry = 0;
+  let last: number | null = null;
+  let frame = 0;
+
+  const unsubscribe = roast.subscribe((value) => {
+    if (value === null) {
+      target = null;
+      shown = 0;
+      carry = 0;
+      set(null);
+      return;
+    }
+    if (prefersReducedMotion) {
+      target = value;
+      shown = value.length;
+      set(value);
+      return;
+    }
+    // Restart when the new text is not a continuation of what is shown,
+    // e.g. the buffered fallback replacing a partial stream.
+    if (target === null || !value.startsWith(target.slice(0, shown))) {
+      shown = 0;
+      carry = 0;
+    }
+    target = value;
+    set(target.slice(0, shown));
+  });
+
+  const tick = (now: number) => {
+    frame = requestAnimationFrame(tick);
+    if (last === null) {
+      last = now;
+      return;
+    }
+    const dt = (now - last) / 1000;
+    last = now;
+    if (target === null || shown >= target.length) {
+      return;
+    }
+    const backlog = target.length - shown;
+    carry += dt * (BASE_CHARS_PER_SECOND + backlog * CATCH_UP_PER_BACKLOG_CHAR);
+    const step = Math.floor(carry);
+    if (step > 0) {
+      carry -= step;
+      shown = Math.min(target.length, shown + step);
+      set(target.slice(0, shown));
+    }
+  };
+  frame = requestAnimationFrame(tick);
+
+  return () => {
+    cancelAnimationFrame(frame);
+    unsubscribe();
+  };
+});
+
+export const isTyping = derived(
+  [roast, displayedRoast],
+  ([$roast, $displayed]) => $roast !== null && $displayed !== $roast
+);


### PR DESCRIPTION
## What

- Consume the new streaming roast endpoint (Lambda Function URL) so first words appear in ~1s instead of waiting 6-10s for the full roast. Falls back to the existing buffered endpoint on any stream failure, so nothing breaks if the new endpoint is unreachable.
- Smooth the streaming presentation: adaptive typewriter reveal with blinking caret, animated roast-card height, fade-in signature footer, Share disabled until the roast finishes typing. All animations respect prefers-reduced-motion.
- Manifest 1.5.0 with the Function URL added to host_permissions (API Gateway entry kept for fallback and old versions).

## Why

Users spend 3-5 seconds on the new tab page; the buffered response usually arrived after they had left.

## Testing

- svelte-check and vite build clean.
- Verified against the live streaming endpoint in Chrome (chrome.* APIs stubbed): skeleton to caret to typed text to footer fade, no console errors.
- Fallback path verified by pointing the stream at an unreachable host: buffered roast still renders.
- Old extension versions are unaffected: the buffered API is unchanged server-side.