### PR TITLE
docs: rebrand to Squad and refresh README + privacy policy

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 BasiliskAI
+Copyright (c) 2023–2026 Squad
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,30 +1,73 @@
-# BrowserBurn Chrome Extension
+# BrowserBurn
 
-Replaces your new tab page with spicy roasts based on your recent browsing history - a unique and fun way to browse every day!
+> Built and maintained by the team at **[Squad](https://meetsquad.ai)**, the product management harness for AI — decision intelligence for teams building software. BrowserBurn is one of the products we *dogfood* on: we plan, build, and ship it with Squad, so every roast is also a real-world test of how we make product decisions. The insults are free. The lessons aren't.
 
-Ever thought your browsing history could have a sense of humor? Let's put that to the test!
+**Your browsing history has opinions about you. Now it shares them.**
 
-How it works:
-With just a couple of clicks, install the extension and you're all set to get roasted in a new tab! BrowserBurn uses advanced AI to analyze your recent browsing history and roasts you based on the websites you've visited. Our AI isn't just any ordinary algorithm; it's been trained on a variety of humorous datasets to ensure each roast is unique and chuckle-worthy. It's like having a virtual friend who knows all your internet secrets and isn't afraid to make fun of you.
+BrowserBurn replaces your new tab with a fresh, personalised roast of your recent browsing. Install it, open a new tab, get roasted. Each burn is written live from your recent page titles and types itself out while you watch. No account, no setup, no mercy.
 
-You can download the extension from the [Chrome Web Store](https://chromewebstore.google.com/detail/blfljajdpgoiehkmnphfikofampdiijm).
+> "You refreshed your own pull request like it was a dating app, hoping someone finally approves of you. At least the AI thinks you're worth talking to."
 
-## Getting started with local development
+**[Install from the Chrome Web Store →](https://chromewebstore.google.com/detail/blfljajdpgoiehkmnphfikofampdiijm)**
 
-- Install dependencies `npm install`
-- Start the dev server `npm run dev`
-- Visit the Extensions page in your browser, click Load Unpacked, and choose the `dist` directory
+## Features
 
-## Build and deploy a local version
+- **Live roasts** — written on the spot, right on your new tab page, typed out one keystroke at a time.
+- **Share cards** — for when the burn is too good to keep to yourself.
+- **Make it yours** — light, dark, or system theme; pick a background colour or bring your own.
+- **Private by design** — only your recent page titles are used to write the roast. Nothing stored, nothing sold.
+- **No sign-up. Ever.**
 
-Note that any code changes you make will not be automatically applied when installing the extension this way. But, it does mean you don't have to run the dev server.
+## Why this repo exists
 
-- Install dependencies `npm install`
-- Build the application `npm run build`
-- Visit the Extensions page in your browser, remove any existing version, click Load Unpacked, and choose the `dist` directory
+BrowserBurn is a real, shipping product — and it's also our sandbox. We build it the same way we build everything at Squad, so it doubles as a proving ground for our own tools and process. If you're curious how Squad approaches product development, this is one place you can watch it happen in the open.
 
-## Recommended IDE Setup
+## Tech stack
 
-This extension is built using [@crxjs/vite-plugin](https://crxjs.dev/vite-plugin) and [Svelte](https://svelte.dev/).
+Built with [Svelte](https://svelte.dev/) and bundled as a Manifest V3 extension using [@crxjs/vite-plugin](https://crxjs.dev/vite-plugin) on top of [Vite](https://vitejs.dev/), styled with [Tailwind CSS](https://tailwindcss.com/) and written in TypeScript.
 
-We recommend [VS Code](https://code.visualstudio.com/) + [Svelte extension](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode).
+## Local development
+
+```bash
+npm install     # install dependencies
+npm run dev     # start the Vite dev server
+```
+
+Then open your browser's Extensions page, enable Developer mode, click **Load unpacked**, and select the `dist` directory. Changes reload automatically while the dev server is running.
+
+## Building a standalone version
+
+Prefer to run the extension without the dev server? Build it once and load the output. Note that code changes won't hot-reload — you'll need to rebuild and reload the extension to see them.
+
+```bash
+npm install     # install dependencies
+npm run build   # produce a production build in dist/
+```
+
+Open the Extensions page, remove any existing BrowserBurn install, click **Load unpacked**, and select the `dist` directory.
+
+## Type checking
+
+```bash
+npm run check   # run svelte-check against the project
+```
+
+## Recommended editor setup
+
+We recommend [VS Code](https://code.visualstudio.com/) with the [Svelte extension](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode).
+
+## Support us
+
+BrowserBurn is free, no sign-up, no ads. But every roast is written live by an AI, and the AI does not work for free. One coffee covers roughly a thousand roasts.
+
+**[Buy us a coffee →](https://buymeacoffee.com/browserburn)**
+
+Questions or problems? [hello@meetsquad.ai](mailto:hello@meetsquad.ai) (mention BrowserBurn).
+
+## License
+
+[MIT](./LICENSE)
+
+---
+
+*Sincerely, your browsing history.*

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "BB🌐🔥",
   "description": "Replaces your new tab page with spicy roasts based on your recent browsing history - a unique and fun way to browse every day!",
   "version": "1.5.0",
-  "author": "BasiliskAI",
+  "author": "Squad",
   "minimum_chrome_version": "104",
   "icons": {
     "16": "icon.png",

--- a/privacy.md
+++ b/privacy.md
@@ -1,6 +1,6 @@
 # Privacy policy
 
-At BasiliskAI, we are committed to protecting your privacy. This Privacy Policy explains how we collect, use, and disclose information when you use our BrowserBurn Chrome Extension ("Extension"). By using the Extension, users agree to these terms.
+At Squad, we are committed to protecting your privacy. This Privacy Policy explains how we collect, use, and disclose information when you use our BrowserBurn Chrome Extension ("Extension"). By using the Extension, users agree to these terms.
 
 ## 1. Information We Collect and How We Use It
 
@@ -8,7 +8,7 @@ We do not store or collect any personally identifiable information about our use
 
 The Extension uses local browser storage to save the users' preference for dark/light mode and 12/24 hour clock display. This information is stored locally on a users device, and we do not have access to it.
 
-It is important to note that the OpenAI v1 chat completions API is used to generate roast content based on page titles accessed by the Extension. Users should refer to the OpenAI Privacy Policy document for information on how they collect, use, and disclose information. BasiliskAI takes no responsibility for data handling by OpenAI once data has been transferred from the Extension to OpenAI via API.
+Roast content is generated using open-weights AI models hosted on [Nscale](https://www.nscale.com/) Serverless Inference, a privacy-respecting sovereign AI cloud that runs its models in Europe. Page titles are sent to Nscale solely to generate a roast. Nscale does not log request or response content; see the [Nscale Privacy Policy](https://www.nscale.com/policies/privacy-policy) for details.
 
 ## 2. Disclosure of Information
 
@@ -28,4 +28,4 @@ We may update this Privacy Policy from time to time. We will post any changes to
 
 ## 6. Contact Us
 
-If you have any questions about this Privacy Policy or our practices, please contact us at hello@basiliskai.com.
+If you have any questions about this Privacy Policy or our practices, please contact us at hello@meetsquad.ai.


### PR DESCRIPTION
Refreshes the repo's public-facing docs and rebrands from BasiliskAI to Squad.

## Changes
- **README** — rewritten in the BrowserBurn voice; framed as a product Squad *dogfoods* (positioning: the product management harness for AI / decision intelligence). Adds features, tech stack, dev/build/type-check instructions, support, and a sign-off.
- **Branding** — `author` (manifest), copyright (LICENSE), and company name (privacy) changed from BasiliskAI to Squad; LICENSE year → 2023–2026.
- **Privacy policy** — corrected the stale OpenAI reference: roasts run on [Nscale](https://www.nscale.com/) serverless inference (privacy-respecting, EU-sovereign, no request/response logging). Contact email → hello@meetsquad.ai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)